### PR TITLE
fix: keep D1 sidebar open after selecting database on mobile

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -716,7 +716,7 @@ setLoading(false);
 };
 
 const selectDb = async (db) => {
-setSelectedDb(db); setResults(null); setSidebarOpen(false);
+setSelectedDb(db); setResults(null);
 setQuery(“SELECT name FROM sqlite_master WHERE type=‘table’ ORDER BY name;”);
 try {
 const d = await cfFetch(accountId, apiKey, `/accounts/${accountId}/d1/database/${db.uuid}/query`, {
@@ -742,7 +742,7 @@ toast(`✓ ${res?.results?.length ?? 0} rows · ${res?.meta?.duration?.toFixed(1
 setLoading(false);
 };
 
-const tableQuery = (t) => { setQuery(`SELECT * FROM "${t}" LIMIT 100;`); };
+const tableQuery = (t) => { setQuery(`SELECT * FROM "${t}" LIMIT 100;`); setSidebarOpen(false); };
 
 return (
 <div className="explorer-layout">

--- a/public/app.jsx
+++ b/public/app.jsx
@@ -758,7 +758,7 @@ function D1Explorer({ accountId, initialDbUuid, initialTable, onNavigate }) {
   };
 
   const selectDb = async (db, autoTable = null) => {
-    setSelectedDb(db); setResults(null); setSidebarOpen(false);
+    setSelectedDb(db); setResults(null);
     setQuery(autoTable ? `SELECT * FROM "${autoTable}" LIMIT 100;` : "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;");
     onNavigate?.(autoTable ? [db.uuid, encodeURIComponent(autoTable)] : [db.uuid]);
     try {
@@ -799,7 +799,7 @@ function D1Explorer({ accountId, initialDbUuid, initialTable, onNavigate }) {
     setLoading(false);
   };
 
-  const tableQuery = (t) => { setQuery(`SELECT * FROM "${t}" LIMIT 100;`); runQuery(`SELECT * FROM "${t}" LIMIT 100;`); onNavigate?.([selectedDb.uuid, encodeURIComponent(t)]); };
+  const tableQuery = (t) => { setQuery(`SELECT * FROM "${t}" LIMIT 100;`); runQuery(`SELECT * FROM "${t}" LIMIT 100;`); onNavigate?.([selectedDb.uuid, encodeURIComponent(t)]); setSidebarOpen(false); };
 
   return (
     <div className="explorer-layout">


### PR DESCRIPTION
On mobile, selecting a database now keeps the sidebar open so the user
can then select a table. The sidebar closes only after a table is selected.

https://claude.ai/code/session_014eiu6p5yqrNv1JCo2W6qE8